### PR TITLE
Replaced resourceGroup().name with resourceGroupName variable

### DIFF
--- a/azure/placeholder-function-app-template.json
+++ b/azure/placeholder-function-app-template.json
@@ -173,7 +173,7 @@
                         "value": "[variables('appServicePlanName')]"
                     },
                     "appServicePlanResourceGroup": {
-                        "value": "[resourceGroup().name]"
+                        "value": "[variables('resourceGroupName')]"
                     },
                     "subnetResourceId": {
                         "value": "[reference('function-app-subnet').outputs.SubnetResourceId.value]"


### PR DESCRIPTION
resourceGroup() function cannot be used as the ARM template is subscription scope