### PR TITLE
Added vnet route all enabled

### DIFF
--- a/azure/placeholder-function-app-template.json
+++ b/azure/placeholder-function-app-template.json
@@ -71,6 +71,10 @@
         "utcValue": {
             "type": "string",
             "defaultValue": "[utcNow()]"
+        },
+        "vnetRouteAllEnabled": {
+            "type": "bool",
+            "defaultValue": false
         }
     },
     "variables": {
@@ -282,6 +286,9 @@
                     },
                     "ipSecurityRestrictions": {
                         "value": "[parameters('workerAccessRestrictions')]"
+                    },
+                    "vnetRouteAllEnabled": {
+                        "value": "[parameters('vnetRouteAllEnabled')]"
                     }
                 }
             },

--- a/azure/placeholder-web-app-sql-template
+++ b/azure/placeholder-web-app-sql-template
@@ -78,6 +78,10 @@
         "utcValue": {
             "type": "string",
             "defaultValue": "[utcNow()]"
+        },
+        "vnetRouteAllEnabled": {
+            "type": "bool",
+            "defaultValue": false
         }
     },
     "variables": {
@@ -240,6 +244,9 @@
                     },
                     "ipSecurityRestrictions": {
                         "value": "[parameters('<frontEndAccessRestrictions> or <backEndAccessRestrictions>')]" //PLACEHOLDER
+                    },
+                    "vnetRouteAllEnabled": {
+                        "value": "[parameters('vnetRouteAllEnabled')]"
                     }
                 }
             },

--- a/azure/placeholder-web-app-template.json
+++ b/azure/placeholder-web-app-template.json
@@ -63,6 +63,10 @@
         "utcValue": {
             "type": "string",
             "defaultValue": "[utcNow()]"
+        },
+        "vnetRouteAllEnabled": {
+            "type": "bool",
+            "defaultValue": false
         }
     },
     "variables": {
@@ -224,6 +228,9 @@
                     },
                     "ipSecurityRestrictions": {
                         "value": "[parameters('<frontEndAccessRestrictions> or <backEndAccessRestrictions>')]" //PLACEHOLDER
+                    },
+                    "vnetRouteAllEnabled": {
+                        "value": "[parameters('vnetRouteAllEnabled')]"
                     }
                 }
             },


### PR DESCRIPTION
This PR adds the 'vnetRouteAllEnabled' parameter to the ARM template and its corresponding usage in the app-service-v2 and function-app-v2 deployments. This is how app services and function apps will be set up going forward.