### PR TITLE
DASD-14156 - Added checkout step to build stage

### DIFF
--- a/pipeline-templates/job/code-build.yml
+++ b/pipeline-templates/job/code-build.yml
@@ -11,6 +11,9 @@ jobs:
   variables:
   - group: BUILD Management Resources
   steps:
+  - checkout: self
+    fetchDepth: 0
+    
   - template: azure-pipelines-templates/build/step/gitversion.yml@das-platform-building-blocks
 
   - template: azure-pipelines-templates/build/step/app-build.yml@das-platform-building-blocks


### PR DESCRIPTION
By adding this to the template the shallow fetch option does not need to be manually deselected when creating a new pipeline. Link to [docs](https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/steps-checkout?view=azure-pipelines#shallow-fetch)

The portal has been changed to use a shallow fetch, similar to how it is when a new pipeline is first created: <img width="2560" height="1275" alt="image" src="https://github.com/user-attachments/assets/6c3b12ab-31f1-4732-94d8-fb9267ceefb6" />

The [pipeline still passes](https://dev.azure.com/sfa-gov-uk/Digital%20Apprenticeship%20Service/_build/results?buildId=1015849&view=results) on the gitversion task as the checkout step in the YAML template has priority
